### PR TITLE
[IMP] website_product_filters: moved text to the left on the browse by category column, it was weird that the title was on the left and the subcategory list on the center. HU#1006 CA#75

### DIFF
--- a/website_product_filters/views/templates.xml
+++ b/website_product_filters/views/templates.xml
@@ -821,7 +821,7 @@
             <!-- Link itself of category with the qty of products -->
             <t t-if="has_product">
               <a t-attf-href="#{categ.child_id and keep('/browse/' + slug(categ), category=0) or keep('/shop/category/' + slug(categ), category=0)}">
-                <div t-att-class="'active' if categ.id == int(category or 0) and categ.child_id else 'text-center inactive subcategory'" t-att-data-categid="categ.id">
+                <div t-att-class="'active' if categ.id == int(category or 0) and categ.child_id else 'text-left inactive subcategory'" t-att-data-categid="categ.id">
                   <t t-esc="'%s ' %(categ.name)"/>
                   <t t-if="categ.id != int(category or 0)">
                     <span class="black-text">


### PR DESCRIPTION
it was weird that the title was on the left and the subcategory list
on the center.

Before:
![browse_by_category___www_yoytec_com](https://cloud.githubusercontent.com/assets/3836433/18069055/3b991c5e-6e0a-11e6-9646-5510007c55c3.png)
After:
![browse_by_category___www_yoytec_com](https://cloud.githubusercontent.com/assets/3836433/18069063/483e3476-6e0a-11e6-9eed-cf4548e37e32.png)
